### PR TITLE
[DM] [SASS-1678] The nrs request now have a client ip and port attached to them

### DIFF
--- a/app/services/NrsService.scala
+++ b/app/services/NrsService.scala
@@ -27,7 +27,14 @@ import scala.concurrent.Future
 class NrsService @Inject() (nrsConnector: NrsConnector) {
 
   def submit(nino: String, nrsSubmissionModel: NrsSubmissionModel, mtditid: String)(implicit hc: HeaderCarrier): Future[NrsSubmissionResponse] = {
-    nrsConnector.postNrsConnector(nino, nrsSubmissionModel)(hc.withExtraHeaders("mtditid" -> mtditid))
+    
+    val extraHeaders = Seq(
+      Some("mtditid" -> mtditid),
+      hc.trueClientIp.map(ip => "clientIP" -> ip),
+      hc.trueClientPort.map(port => "clientPort" -> port)
+    ).flatten
+    
+    nrsConnector.postNrsConnector(nino, nrsSubmissionModel)(hc.withExtraHeaders(extraHeaders: _*))
   }
 
 }


### PR DESCRIPTION
The NRS Service layer will now add the trueClientIp and trueClientPort to the headers if they exist, which realistically, they always will. This will be used by the NRS proxy to populate the metadata of the NRS request.

Add a link to the relevant story in Jira
[SASS-1678](https://jira.tools.tax.service.gov.uk/browse/SASS-1678)

### Checklist PR Reviewer
##### Before Reviewing
- [x]  Have you pulled the branch down?
- [x]  Have you assigned yourself to the PR?
- [x]  Have you moved the task to “in review” on JIRA?
- [ ]  Have you checked to ensure all dependencies are up to date?
- [x]  Have you checked to ensure its been rebased against the current version of main?

##### Whilst Reviewing
- [x]  Have you run the tests?
- [x]  Have you run the journey tests?
- [x]  Have you looked at the JIRA story to make sure all Acceptance Criteria has been met?

##### After Reviewing
- [x]  Have you checked for merge conflicts or any changes in the current main that may affect the current pull request? i.e. does it need another rebase?
- [x]  Have you checked to make sure there are no builds in the pipeline before you merge?
- [ ]  Have you moved the task to “in pipeline” on Jira?

### Checklist PR Raiser
##### Before creating PR
- [x]  Have you run the tests?
- [ ]  Have you run the journey tests? (where applicable)
- [x]  Have you addressed warnings where appropriate?
- [x]  Have you rebased against the current version of main?
- [x]  Have you checked code coverage isn’t lower than previously?

##### After PRs been raised
- [ ]  Have you checked the PR Builder passes?
