### PR TITLE
SASS-2510 Removing non-functional print link from confirmation page

### DIFF
--- a/app/views/TaxReturnReceivedView.scala.html
+++ b/app/views/TaxReturnReceivedView.scala.html
@@ -76,11 +76,6 @@
 
         <p class="govuk-body govuk-!-margin-bottom-8">@messages(s"taxReturnReceived.nextSteps.p4.${if(isAgent) "agent" else "individual"}")</p>
 
-        <p class="govuk-body-m">
-            <a class="govuk-link" id="print_link">
-                @messages("taxReturnReceived.print")
-            </a>
-        </p>
     </div>
 }
 @layout(pageTitle = messages(s"taxReturnReceived.title.${if(isAgent) "agent" else "individual"}"), taxYear = Some(taxYear), isAgent = isAgent, showBreadcrumbs = false)(mainHTML)

--- a/it/controllers/TaxReturnReceivedControllerISpec.scala
+++ b/it/controllers/TaxReturnReceivedControllerISpec.scala
@@ -67,8 +67,6 @@ class TaxReturnReceivedControllerISpec extends IntegrationTest with ImplicitDate
     val summaryRow1Key: String = "Name"
     val summaryRow2Key: String = "Unique Tax Reference (UTR)"
     val summaryRow3Key: String = "Date submitted"
-    val nextStepsPrint: String = "Print this page"
-    val printLink: String = ""
 
     val summaryRow1KeyWelsh: String = "Enw"
     val summaryRow2KeyWelsh: String = "Cyfeirnod Unigryw y Trethdalwr (UTR)"
@@ -150,7 +148,6 @@ class TaxReturnReceivedControllerISpec extends IntegrationTest with ImplicitDate
     val nextStepsP1TextSelector = "#main-content > div > div > div.govuk-body > p:nth-child(1)"
     val nextStepsP2LinkSelector = "#amount_owed_link"
     val nextStepsP4TextSelector = "#main-content > div > div > div.govuk-body > p:nth-child(2)"
-    val printLinkSelector = "#print_link"
   }
 
   import ExpectedResults._
@@ -199,7 +196,6 @@ class TaxReturnReceivedControllerISpec extends IntegrationTest with ImplicitDate
         textOnPageCheck(nextStepsP1, nextStepsP1TextSelector)
         linkCheck(nextStepsP2, nextStepsP2LinkSelector, nextStepsP2Link)
         textOnPageCheck(nextStepsP4, nextStepsP4TextSelector)
-        linkCheck(nextStepsPrint, printLinkSelector, printLink)
       }
 
     }
@@ -240,7 +236,6 @@ class TaxReturnReceivedControllerISpec extends IntegrationTest with ImplicitDate
         textOnPageCheck(nextStepsP1Welsh, nextStepsP1TextSelector)
         linkCheck(nextStepsP2Welsh, nextStepsP2LinkSelector, nextStepsP2Link)
         textOnPageCheck(nextStepsP4Welsh, nextStepsP4TextSelector)
-        linkCheck(nextStepsPrintWelsh, printLinkSelector, printLink)
       }
     }
   }
@@ -286,7 +281,6 @@ class TaxReturnReceivedControllerISpec extends IntegrationTest with ImplicitDate
         textOnPageCheck(nextStepsP1, nextStepsP1TextSelector)
         linkCheck(nextStepsP2, nextStepsP2LinkSelector, nextStepsP2Link)
         textOnPageCheck(nextStepsP4, nextStepsP4TextSelector)
-        linkCheck(nextStepsPrint, printLinkSelector, printLink)
       }
 
     }
@@ -329,7 +323,6 @@ class TaxReturnReceivedControllerISpec extends IntegrationTest with ImplicitDate
         textOnPageCheck(nextStepsP1Welsh, nextStepsP1TextSelector)
         linkCheck(nextStepsP2Welsh, nextStepsP2LinkSelector, nextStepsP2Link)
         textOnPageCheck(nextStepsP4Welsh, nextStepsP4TextSelector)
-        linkCheck(nextStepsPrintWelsh, printLinkSelector, printLink)
       }
     }
   }


### PR DESCRIPTION
### Description
Accessibility issue - Removing a non-functional print link from the confirmation page

Add a link to the relevant story in Jira
Parent ticket -> [SASS-2331](https://jira.tools.tax.service.gov.uk/browse/SASS-2331)

### Checklist PR Reviewer
##### Before Reviewing
- [x]  Have you pulled the branch down?
- [x]  Have you assigned yourself to the PR?
- [x]  Have you moved the task to “in review” on JIRA?
- [x]  Have you checked to ensure all dependencies are up to date?
- [x]  Have you checked to ensure its been rebased against the current version of main?

##### Whilst Reviewing
- [x]  Have you run the tests?
- [x]  Have you run the journey tests?
- [ ]  Have you looked at the JIRA story to make sure all Acceptance Criteria has been met?

##### After Reviewing
- [x]  Have you checked for merge conflicts or any changes in the current main that may affect the current pull request? i.e. does it need another rebase?
- [x]  Have you checked to make sure there are no builds in the pipeline before you merge?
- [ ]  Have you moved the task to “in pipeline” on Jira?

### Checklist PR Raiser
##### Before creating PR
- [x]  Have you run the tests?
- [x]  Have you run the journey tests? (where applicable)
- [x]  Have you addressed warnings where appropriate?
- [x]  Have you rebased against the current version of main?
- [x]  Have you checked code coverage isn’t lower than previously?

##### After PRs been raised
- [ ]  Have you checked the PR Builder passes?
