### PR TITLE
SASS-3048: Employment In year no data/pre-pop design iteration

### DIFF
--- a/app/views/OverviewPageView.scala.html
+++ b/app/views/OverviewPageView.scala.html
@@ -145,9 +145,7 @@
             appConfig.employmentFEUrl(taxYear),
             EMPLOYMENT,
             incomeSources.employment.isDefined,
-            (isInYear || !appConfig.employmentEOYEnabled),
-            isMandatorySection = true,
-            additionalShowLinkCheck = ((incomeSources.employment.isDefined && isInYear) || (appConfig.employmentEOYEnabled && !isInYear))
+            (isInYear || !appConfig.employmentEOYEnabled)
         )
 
         @taskListItem(

--- a/it/controllers/overviewPage/OverviewPageControllerISpec.scala
+++ b/it/controllers/overviewPage/OverviewPageControllerISpec.scala
@@ -1064,7 +1064,7 @@ class OverviewPageControllerISpec extends IntegrationTest with ViewHelpers with 
 
           "has an employment section " which {
             linkCheck(employmentSLLinkText, employmentLinkSelector, employmentLink(taxYearEOY))
-            textOnPageCheck(todoText, employmentStatusSelector)
+            textOnPageCheck(notStartedText, employmentStatusSelector)
           }
 
           "has a cis section " which {

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -19,7 +19,7 @@ import sbt._
 
 object AppDependencies {
 
-  private val bootstrapPlay28Version = "6.3.0"
+  private val bootstrapPlay28Version = "6.4.0"
 
   val compile: Seq[ModuleID] = Seq(
     "uk.gov.hmrc"                   %% "bootstrap-frontend-play-28" % bootstrapPlay28Version,


### PR DESCRIPTION
### Description
Make the `PAYE employment` text a hyperlink if income sources are not defined.

This allows the user to navigate to the employment summary page if they have no prior data.

[SASS-3048](https://jira.tools.tax.service.gov.uk/browse/SASS-3048)

### Checklist PR Reviewer
##### Before Reviewing
- [x]  Have you pulled the branch down?
- [x]  Have you assigned yourself to the PR?
- [x]  Have you moved the task to “in review” on JIRA?
- [x]  Have you checked to ensure all dependencies are up to date?
- [x]  Have you checked to ensure its been rebased against the current version of main?

##### Whilst Reviewing
- [x]  Have you run the tests?
- [x]  Have you run the journey tests?
- [x]  Have you looked at the JIRA story to make sure all Acceptance Criteria has been met?

##### After Reviewing
- [x]  Have you checked for merge conflicts or any changes in the current main that may affect the current pull request? i.e. does it need another rebase?
- [ ]  Have you checked to make sure there are no builds in the pipeline before you merge?
- [ ]  Have you moved the task to “in pipeline” on Jira?

### Checklist PR Raiser
##### Before creating PR
- [X]  Have you run the tests?
- [ ]  Have you run the journey tests? (where applicable)
- [X]  Have you addressed warnings where appropriate?
- [X]  Have you rebased against the current version of main?
- [X]  Have you checked code coverage isn’t lower than previously?

##### After PRs been raised
- [x]  Have you checked the PR Builder passes?
