### PR TITLE
[SASS-10575] Add new secondary agent delegated auth check

### DIFF
--- a/app/common/EnrolmentCommon.scala
+++ b/app/common/EnrolmentCommon.scala
@@ -18,6 +18,7 @@ package common
 
 object EnrolmentKeys {
   val Individual = "HMRC-MTD-IT"
+  val SupportingAgent = "HMRC-MTD-IT-SUPP"
   val Agent = "HMRC-AS-AGENT"
   val nino =  "HMRC-NI"
 }
@@ -26,4 +27,9 @@ object EnrolmentIdentifiers {
   val individualId = "MTDITID"
   val agentReference = "AgentReferenceNumber"
   val ninoId = "NINO"
+}
+
+object DelegatedAuthRules {
+  val agentDelegatedAuthRule = "mtd-it-auth"
+  val supportingAgentDelegatedAuthRule = "mtd-it-auth-supp"
 }

--- a/app/config/AppConfig.scala
+++ b/app/config/AppConfig.scala
@@ -35,7 +35,7 @@ class FrontendAppConfig @Inject()(servicesConfig: ServicesConfig) extends AppCon
   private lazy val signInContinueBaseUrl: String = servicesConfig.getString(ConfigKeys.signInContinueUrl)
   lazy val signInContinueUrl: String = SafeRedirectUrl(signInContinueBaseUrl).encodedUrl //TODO add redirect to overview page
   private lazy val signInOrigin = servicesConfig.getString("appName")
-  lazy val signInUrl: String = s"$signInBaseUrl?continue=$signInContinueUrl&origin=$signInOrigin"
+  def signInUrl: String = s"$signInBaseUrl?continue=$signInContinueUrl&origin=$signInOrigin"
 
   lazy val calculationBaseUrl: String = servicesConfig.getString(ConfigKeys.incomeTaxCalculationUrl)
   lazy val nrsProxyBaseUrl: String = servicesConfig.getString(ConfigKeys.incomeTaxNrsProxyUrl)
@@ -212,6 +212,8 @@ class FrontendAppConfig @Inject()(servicesConfig: ServicesConfig) extends AppCon
     ).filter(!_._2).map(_._1)
   }
 
+  def emaSupportingAgentsEnabled: Boolean = servicesConfig.getBoolean("feature-switch.ema-supporting-agents-enabled")
+
   lazy val useEncryption: Boolean = servicesConfig.getBoolean("useEncryption")
   lazy val encryptionKey: String = servicesConfig.getString("mongodb.encryption.key")
   def mongoTTL: Long = Duration(servicesConfig.getString("mongodb.timeToLive")).toDays.toInt
@@ -223,7 +225,7 @@ class FrontendAppConfig @Inject()(servicesConfig: ServicesConfig) extends AppCon
 trait AppConfig {
   def defaultTaxYear: Int
   val signInContinueUrl: String
-  val signInUrl: String
+  def signInUrl: String
   val alwaysEOY: Boolean
 
   val calculationBaseUrl: String
@@ -357,6 +359,8 @@ trait AppConfig {
   def tailorReturnAddSectionsPageUrl(taxYear: Int): String
 
   def excludedIncomeSources(taxYear: Int): Seq[String]
+
+  def emaSupportingAgentsEnabled: Boolean
 
   val useEncryption: Boolean
   val encryptionKey: String

--- a/app/controllers/predicates/AuthorisedAction.scala
+++ b/app/controllers/predicates/AuthorisedAction.scala
@@ -16,7 +16,7 @@
 
 package controllers.predicates
 
-import common.{EnrolmentIdentifiers, EnrolmentKeys, SessionValues}
+import common.{DelegatedAuthRules, EnrolmentIdentifiers, EnrolmentKeys, SessionValues}
 import config.AppConfig
 import controllers.routes
 import models.User
@@ -25,10 +25,11 @@ import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.Results._
 import play.api.mvc._
 import services.AuthService
+import uk.gov.hmrc.auth.core.authorise.Predicate
 import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals.{affinityGroup, allEnrolments, confidenceLevel}
 import uk.gov.hmrc.auth.core.retrieve.~
-import uk.gov.hmrc.auth.core.{ConfidenceLevel, _}
-import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.auth.core._
+import uk.gov.hmrc.http.{HeaderCarrier, SessionKeys}
 import uk.gov.hmrc.play.http.HeaderCarrierConverter
 import views.html.authErrorPages.AgentAuthErrorPageView
 
@@ -50,6 +51,19 @@ class AuthorisedAction @Inject()(appConfig: AppConfig,
   val minimumConfidenceLevel: Int = ConfidenceLevel.L250.level
 
   override def parser: BodyParser[AnyContent] = mcc.parsers.default
+
+  private def sessionIdBlock(errorLogString: String, errorAction: Future[Result])
+                            (block: String => Future[Result])
+                            (implicit request: Request[_], hc: HeaderCarrier): Future[Result] =
+    hc.sessionId match {
+      case Some(sessionId) => block(sessionId.value)
+      case _ => request.headers.get(SessionKeys.sessionId) match {
+        case Some(sessionId) => block(sessionId)
+        case _ =>
+          logger.info(errorLogString)
+          errorAction
+      }
+    }
 
   override def invokeBlock[A](request: Request[A], block: User[A] => Future[Result]): Future[Result] = {
 
@@ -81,17 +95,6 @@ class AuthorisedAction @Inject()(appConfig: AppConfig,
     }
   }
 
-  def sessionId(implicit request: Request[_], hc: HeaderCarrier): Option[String] = {
-    lazy val key = "sessionId"
-    if (hc.sessionId.isDefined) {
-      hc.sessionId.map(_.value)
-    } else if (request.headers.get(key).isDefined) {
-      request.headers.get(key)
-    } else {
-      None
-    }
-  }
-
   def individualAuthentication[A](block: User[A] => Future[Result])
                                  (implicit request: Request[A], hc: HeaderCarrier): Future[Result] = {
     authService.authorised().retrieve(allEnrolments and confidenceLevel) {
@@ -101,15 +104,12 @@ class AuthorisedAction @Inject()(appConfig: AppConfig,
 
         (optionalMtdItId, optionalNino) match {
           case (Some(mtdItId), Some(nino)) =>
-
-            sessionId.fold {
-              logger.info(s"[AuthorisedAction][individualAuthentication] - No session id in request")
-
-              Future.successful(Redirect(appConfig.signInUrl))
-            } { sessionId =>
-              block(User(mtdItId, None, nino, sessionId))
-            }
-
+            sessionIdBlock(
+              errorLogString = s"[AuthorisedAction][individualAuthentication] - No session id in request",
+              errorAction = Future.successful(Redirect(appConfig.signInUrl))
+            )(
+              sessionId => block(User(mtdItId, None, nino, sessionId))
+            )
           case (_, None) =>
             logger.info(s"[AuthorisedAction][individualAuthentication] - No active session. Redirecting to ${appConfig.signInUrl}")
             Future.successful(Redirect(appConfig.signInUrl))
@@ -123,53 +123,72 @@ class AuthorisedAction @Inject()(appConfig: AppConfig,
     }
   }
 
+  private[predicates] def agentAuthPredicate(mtdId: String): Predicate =
+    Enrolment(EnrolmentKeys.Individual)
+      .withIdentifier(EnrolmentIdentifiers.individualId, mtdId)
+      .withDelegatedAuthRule(DelegatedAuthRules.agentDelegatedAuthRule)
+
+  private[predicates] def secondaryAgentPredicate(mtdId: String): Predicate =
+    Enrolment(EnrolmentKeys.SupportingAgent)
+      .withIdentifier(EnrolmentIdentifiers.individualId, mtdId)
+      .withDelegatedAuthRule(DelegatedAuthRules.supportingAgentDelegatedAuthRule)
+
   private[predicates] def agentAuthentication[A](block: User[A] => Future[Result])
-                                                (implicit request: Request[A], hc: HeaderCarrier): Future[Result] = {
-
-    lazy val agentDelegatedAuthRuleKey = "mtd-it-auth"
-
-    lazy val agentAuthPredicate: String => Enrolment = identifierId =>
-      Enrolment(EnrolmentKeys.Individual)
-        .withIdentifier(EnrolmentIdentifiers.individualId, identifierId)
-        .withDelegatedAuthRule(agentDelegatedAuthRuleKey)
-
-    val optionalNino = request.session.get(SessionValues.CLIENT_NINO)
-    val optionalMtdItId = request.session.get(SessionValues.CLIENT_MTDITID)
-
-    (optionalMtdItId, optionalNino) match {
+                                                (implicit request: Request[A], hc: HeaderCarrier): Future[Result] =
+    (request.session.get(SessionValues.CLIENT_MTDITID), request.session.get(SessionValues.CLIENT_NINO)) match {
       case (Some(mtdItId), Some(nino)) =>
         authService
           .authorised(agentAuthPredicate(mtdItId))
-          .retrieve(allEnrolments) { enrolments =>
-
-            enrolmentGetIdentifierValue(EnrolmentKeys.Agent, EnrolmentIdentifiers.agentReference, enrolments) match {
-              case Some(arn) =>
-
-                sessionId.fold {
-                  logger.info(s"[AuthorisedAction][agentAuthentication] - No session id in request")
-                  Future(Redirect(appConfig.signInUrl))
-                } { sessionId =>
-                  block(User(mtdItId, Some(arn), nino, sessionId))
-                }
-
-              case None =>
-                logger.info("[AuthorisedAction][agentAuthentication] Agent with no HMRC-AS-AGENT enrolment. Rendering unauthorised view.")
-                Future.successful(Redirect(controllers.errors.routes.YouNeedAgentServicesController.show))
-            }
-          } recover {
-          case _: NoActiveSession =>
-            logger.info(s"[AuthorisedAction][agentAuthentication] - No active session. Redirecting to ${appConfig.signInUrl}")
-            Redirect(appConfig.signInUrl)
-          case ex: AuthorisationException =>
-            logger.info(s"[AuthorisedAction][agentAuthentication] - Agent does not have delegated authority for Client.")
-            Redirect(controllers.errors.routes.AgentAuthErrorController.show)
-        }
+          .retrieve(allEnrolments) {
+            populateAgent(block, mtdItId, nino, _, isSecondaryAgent = false)
+          }.recoverWith(agentRecovery(block, mtdItId, nino))
       case (mtditid, nino) =>
         logger.info(s"[AuthorisedAction][agentAuthentication] - Agent does not session key values. Redirecting to view & change." +
           s"MTDITID missing:${mtditid.isEmpty}, NINO missing:${nino.isEmpty}")
         Future.successful(Redirect(appConfig.viewAndChangeEnterUtrUrl))
     }
+
+  private def agentRecovery[A](block: User[A] => Future[Result],
+                               mtdItId: String,
+                               nino: String)
+                              (implicit request: Request[A], hc: HeaderCarrier): PartialFunction[Throwable, Future[Result]] = {
+    case _: NoActiveSession =>
+      logger.info(s"[AuthorisedAction][agentAuthentication] - No active session. Redirecting to ${appConfig.signInUrl}")
+      Future(Redirect(appConfig.signInUrl))
+    case _: AuthorisationException =>
+      if (appConfig.emaSupportingAgentsEnabled) {
+        authService
+          .authorised(secondaryAgentPredicate(mtdItId))
+          .retrieve(allEnrolments) {
+            populateAgent(block, mtdItId, nino, _, isSecondaryAgent = true)
+          }.recoverWith {
+            case _ =>
+              logger.info(s"[AuthorisedAction][agentAuthentication] - Agent does not have secondary delegated authority for Client.")
+              Future(Redirect(controllers.errors.routes.AgentAuthErrorController.show))
+          }
+      } else {
+        logger.info(s"[AuthorisedAction][agentAuthentication] - Agent does not have delegated authority for Client.")
+        Future(Redirect(controllers.errors.routes.AgentAuthErrorController.show))
+      }
   }
+
+  private def populateAgent[A](block: User[A] => Future[Result],
+                               mtdItId: String,
+                               nino: String,
+                               enrolments: Enrolments,
+                               isSecondaryAgent: Boolean)(implicit request: Request[A], hc: HeaderCarrier): Future[Result] =
+    enrolmentGetIdentifierValue(EnrolmentKeys.Agent, EnrolmentIdentifiers.agentReference, enrolments) match {
+      case Some(arn) =>
+        sessionIdBlock(
+          errorLogString = s"[AuthorisedAction][agentAuthentication] - No session id in request",
+          errorAction = Future.successful(Redirect(appConfig.signInUrl))
+        )(sessionId =>
+          block(User(mtdItId, Some(arn), nino, sessionId, isSecondaryAgent))
+        )
+      case None =>
+        logger.info("[AuthorisedAction][agentAuthentication] - Agent with no HMRC-AS-AGENT enrolment. Rendering unauthorised view.")
+        Future.successful(Redirect(controllers.errors.routes.YouNeedAgentServicesController.show))
+    }
 
   private[predicates] def enrolmentGetIdentifierValue(
                                                        checkedKey: String,

--- a/app/models/User.scala
+++ b/app/models/User.scala
@@ -21,7 +21,8 @@ import play.api.mvc.{Request, WrappedRequest}
 case class User[T](mtditid: String,
                    arn: Option[String],
                    nino: String,
-                   sessionId: String)
+                   sessionId: String,
+                   isSecondaryAgent: Boolean = false)
                   (implicit request: Request[T]) extends WrappedRequest[T](request) {
   def isAgent: Boolean = arn.nonEmpty
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -192,6 +192,7 @@ feature-switch {
     crystallisationEnabled = true
     tailoringEnabled = true
     tailoringPhase2Enabled = false
+    ema-supporting-agents-enabled = true
 }
 mongodb {
   encryption.key = "QmFyMTIzNDVCYXIxMjM0NQ=="

--- a/test/common/EnrolmentCommonSpec.scala
+++ b/test/common/EnrolmentCommonSpec.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package common
+
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class EnrolmentCommonSpec extends AnyWordSpec with Matchers {
+
+  "EnrolmentKeys" should {
+    "have the correct values" in {
+      EnrolmentKeys.Individual mustBe "HMRC-MTD-IT"
+      EnrolmentKeys.SupportingAgent mustBe "HMRC-MTD-IT-SUPP"
+      EnrolmentKeys.Agent mustBe "HMRC-AS-AGENT"
+      EnrolmentKeys.nino mustBe "HMRC-NI"
+    }
+  }
+
+  "EnrolmentIdentifiers" should {
+    "have the correct values" in {
+      EnrolmentIdentifiers.individualId mustBe "MTDITID"
+      EnrolmentIdentifiers.agentReference mustBe "AgentReferenceNumber"
+      EnrolmentIdentifiers.ninoId mustBe "NINO"
+    }
+  }
+
+  "DelegatedAuthRules" should {
+    "have the correct values" in {
+      DelegatedAuthRules.agentDelegatedAuthRule mustBe "mtd-it-auth"
+      DelegatedAuthRules.supportingAgentDelegatedAuthRule mustBe "mtd-it-auth-supp"
+    }
+  }
+
+}

--- a/test/config/MockAppConfig.scala
+++ b/test/config/MockAppConfig.scala
@@ -207,6 +207,7 @@ class MockAppConfig extends AppConfig with MockFactory with TaxYearHelper {
     "cymraeg" -> Lang("cy")
   )
 
+  override def emaSupportingAgentsEnabled: Boolean = false
 
   override val useEncryption: Boolean = true
   override val encryptionKey: String = "1234556"

--- a/test/controllers/predicates/AuthorisedActionSpec.scala
+++ b/test/controllers/predicates/AuthorisedActionSpec.scala
@@ -1,0 +1,482 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.predicates
+
+import common.{DelegatedAuthRules, EnrolmentIdentifiers, EnrolmentKeys, SessionValues}
+import config.AppConfig
+import models.User
+import org.scalamock.handlers.{CallHandler0, CallHandler4}
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.http.Status._
+import play.api.mvc.Results._
+import play.api.mvc.{AnyContent, AnyContentAsEmpty, Result}
+import play.api.test.FakeRequest
+import uk.gov.hmrc.auth.core._
+import uk.gov.hmrc.auth.core.authorise.Predicate
+import uk.gov.hmrc.auth.core.retrieve.Retrieval
+import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals
+import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals.{allEnrolments, confidenceLevel}
+import uk.gov.hmrc.auth.core.syntax.retrieved.authSyntaxForRetrieved
+import uk.gov.hmrc.http.{HeaderCarrier, SessionId}
+import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
+import utils.UnitTest
+import views.html.authErrorPages.AgentAuthErrorPageView
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class AuthorisedActionSpec extends UnitTest with GuiceOneAppPerSuite {
+
+  val agentAuthErrorPageView: AgentAuthErrorPageView = app.injector.instanceOf[AgentAuthErrorPageView]
+  val authorisedAction = new AuthorisedAction(mockAppConfig, agentAuthErrorPageView)(mockAuthService, stubMessagesControllerComponents())
+
+  val auth: AuthorisedAction = authorisedAction
+  val nino: String = "AA123456A"
+  val block: User[AnyContent] => Future[Result] = user => Future.successful(Ok(user.mtditid))
+  val mtditid = "1234567890"
+
+  trait AgentTest {
+
+    val arn: String = "0987654321"
+
+    val baseUrl = "/update-and-submit-income-tax-return"
+    val viewAndChangeUrl: String = "/report-quarterly/income-and-expenses/view/agents/client-utr"
+    val signInUrl: String = s"$baseUrl/signIn"
+
+    val validHeaderCarrier: HeaderCarrier = HeaderCarrier(sessionId = Some(SessionId("sessionId")))
+
+    val testBlock: User[AnyContent] => Future[Result] = user => Future.successful(Ok(s"${user.mtditid} ${user.arn.get}"))
+
+    val mockAppConfig: AppConfig = mock[AppConfig]
+
+    def primaryAgentPredicate(mtdId: String): Predicate =
+      Enrolment(EnrolmentKeys.Individual)
+        .withIdentifier(EnrolmentIdentifiers.individualId, mtdId)
+        .withDelegatedAuthRule(DelegatedAuthRules.agentDelegatedAuthRule)
+
+    def secondaryAgentPredicate(mtdId: String): Predicate =
+      Enrolment(EnrolmentKeys.SupportingAgent)
+        .withIdentifier(EnrolmentIdentifiers.individualId, mtdId)
+        .withDelegatedAuthRule(DelegatedAuthRules.supportingAgentDelegatedAuthRule)
+
+    def mockMultipleAgentsSwitch(bool: Boolean): CallHandler0[Boolean] =
+      (mockAppConfig.emaSupportingAgentsEnabled _: () => Boolean)
+        .expects()
+        .returning(bool)
+        .anyNumberOfTimes()
+
+    val primaryAgentEnrolment: Enrolments = Enrolments(Set(
+      Enrolment(EnrolmentKeys.Individual, Seq(EnrolmentIdentifier(EnrolmentIdentifiers.individualId, mtditid)), "Activated"),
+      Enrolment(EnrolmentKeys.Agent, Seq(EnrolmentIdentifier(EnrolmentIdentifiers.agentReference, arn)), "Activated")
+    ))
+
+    val supportingAgentEnrolment: Enrolments = Enrolments(Set(
+      Enrolment(EnrolmentKeys.SupportingAgent, Seq(EnrolmentIdentifier(EnrolmentIdentifiers.individualId, mtditid)), "Activated"),
+      Enrolment(EnrolmentKeys.Agent, Seq(EnrolmentIdentifier(EnrolmentIdentifiers.agentReference, arn)), "Activated")
+    ))
+
+    def mockAuthReturnException(exception: Exception,
+                                predicate: Predicate): CallHandler4[Predicate, Retrieval[_], HeaderCarrier, ExecutionContext, Future[Any]] =
+      (mockAuthConnector.authorise(_: Predicate, _: Retrieval[_])(_: HeaderCarrier, _: ExecutionContext))
+        .expects(predicate, *, *, *)
+        .returning(Future.failed(exception))
+
+    def mockAuthReturn(enrolments: Enrolments, predicate: Predicate): CallHandler4[Predicate, Retrieval[_], HeaderCarrier, ExecutionContext, Future[Any]] =
+      (mockAuthConnector.authorise(_: Predicate, _: Retrieval[_])(_: HeaderCarrier, _: ExecutionContext))
+        .expects(predicate, *, *, *)
+        .returning(Future.successful(enrolments))
+
+    def mockSignInUrl(): CallHandler0[String] =
+      (mockAppConfig.signInUrl _: () => String)
+        .expects()
+        .returning(signInUrl)
+        .anyNumberOfTimes()
+
+    def mockViewAndChangeUrl(): CallHandler0[String] =
+      (mockAppConfig.viewAndChangeEnterUtrUrl _: () => String)
+        .expects()
+        .returning(viewAndChangeUrl)
+        .anyNumberOfTimes()
+
+    def testAuth: AuthorisedAction = {
+      mockViewAndChangeUrl()
+      mockSignInUrl()
+
+      new AuthorisedAction(
+        appConfig = mockAppConfig,
+        agentAuthErrorPage = agentAuthErrorPageView
+      )(
+        authService = mockAuthService,
+        mcc = stubMessagesControllerComponents()
+      )
+    }
+
+    lazy val fakeRequestWithMtditidAndNino: FakeRequest[AnyContentAsEmpty.type] = fakeRequest.withSession(
+      SessionValues.TAX_YEAR -> "2022",
+      SessionValues.CLIENT_MTDITID -> mtditid,
+      SessionValues.CLIENT_NINO -> nino
+    )
+  }
+
+  ".enrolmentGetIdentifierValue" should {
+    "return the value for the given identifier" in {
+      val returnValue = "anIdentifierValue"
+      val returnValueAgent = "anAgentIdentifierValue"
+
+      val enrolments = Enrolments(Set(
+        Enrolment(EnrolmentKeys.Individual, Seq(EnrolmentIdentifier(EnrolmentIdentifiers.individualId, returnValue)), "Activated"),
+        Enrolment(EnrolmentKeys.Agent, Seq(EnrolmentIdentifier(EnrolmentIdentifiers.agentReference, returnValueAgent)), "Activated")
+      ))
+
+      auth.enrolmentGetIdentifierValue(EnrolmentKeys.Individual, EnrolmentIdentifiers.individualId, enrolments) shouldBe Some(returnValue)
+      auth.enrolmentGetIdentifierValue(EnrolmentKeys.Agent, EnrolmentIdentifiers.agentReference, enrolments) shouldBe Some(returnValueAgent)
+    }
+
+    "return a None" when {
+      val key = "someKey"
+      val identifierKey = "anIdentifier"
+      val returnValue = "anIdentifierValue"
+
+      val enrolments = Enrolments(Set(Enrolment(key, Seq(EnrolmentIdentifier(identifierKey, returnValue)), "someState")))
+
+
+      "the given identifier cannot be found" in {
+        auth.enrolmentGetIdentifierValue(key, "someOtherIdentifier", enrolments) shouldBe None
+      }
+
+      "the given key cannot be found" in {
+        auth.enrolmentGetIdentifierValue("someOtherKey", identifierKey, enrolments) shouldBe None
+      }
+
+    }
+
+  }
+
+  ".individualAuthentication" should {
+    "perform the block action" when {
+      "the correct enrolment exist" which {
+
+        val enrolments = Enrolments(Set(
+          Enrolment(EnrolmentKeys.Individual, Seq(EnrolmentIdentifier(EnrolmentIdentifiers.individualId, mtditid)), "Activated"),
+          Enrolment(EnrolmentKeys.nino, Seq(EnrolmentIdentifier(EnrolmentIdentifiers.ninoId, nino)), "Activated")
+        ))
+
+        lazy val result: Future[Result] = {
+          (mockAuthConnector.authorise(_: Predicate, _: Retrieval[_])(_: HeaderCarrier, _: ExecutionContext))
+            .expects(*, allEnrolments and confidenceLevel, *, *)
+            .returning(Future.successful(enrolments and ConfidenceLevel.L250))
+          auth.individualAuthentication[AnyContent](block)(fakeRequest, emptyHeaderCarrier)
+        }
+
+        "returns an OK status" in {
+          status(result) shouldBe OK
+        }
+
+        "returns a body of the mtditid" in {
+          bodyOf(result) shouldBe mtditid
+        }
+      }
+
+    }
+
+    "return a redirect" when {
+
+      "the nino enrolment is missing" which {
+
+        val enrolments = Enrolments(Set())
+
+        lazy val result: Future[Result] = {
+          (mockAuthConnector.authorise(_: Predicate, _: Retrieval[_])(_: HeaderCarrier, _: ExecutionContext))
+            .expects(*, allEnrolments and confidenceLevel, *, *)
+            .returning(Future.successful(enrolments and ConfidenceLevel.L250))
+          auth.individualAuthentication[AnyContent](block)(fakeRequest, emptyHeaderCarrier)
+        }
+
+        "returns a forbidden" in {
+          status(result) shouldBe SEE_OTHER
+        }
+      }
+
+      "the individual enrolment is missing but there is a nino" which {
+
+        val enrolments = Enrolments(Set(Enrolment("HMRC-NI", Seq(EnrolmentIdentifier(EnrolmentIdentifiers.ninoId, nino)), "Activated")))
+
+        lazy val result: Future[Result] = {
+          (mockAuthConnector.authorise(_: Predicate, _: Retrieval[_])(_: HeaderCarrier, _: ExecutionContext))
+            .expects(*, allEnrolments and confidenceLevel, *, *)
+            .returning(Future.successful(enrolments and ConfidenceLevel.L250))
+          auth.individualAuthentication[AnyContent](block)(fakeRequest, emptyHeaderCarrier)
+        }
+
+        "returns an Unauthorised" in {
+          status(result) shouldBe SEE_OTHER
+        }
+        "returns an redirect to the correct page" in {
+          redirectUrl(result) shouldBe "/update-and-submit-income-tax-return/error/you-need-to-sign-up"
+        }
+      }
+
+      "there is no session id" which {
+
+        val enrolments = Enrolments(Set(
+          Enrolment(EnrolmentKeys.Individual, Seq(EnrolmentIdentifier(EnrolmentIdentifiers.individualId, mtditid)), "Activated"),
+          Enrolment(EnrolmentKeys.nino, Seq(EnrolmentIdentifier(EnrolmentIdentifiers.ninoId, nino)), "Activated")
+        ))
+
+        lazy val result: Future[Result] = {
+          (mockAuthConnector.authorise(_: Predicate, _: Retrieval[_])(_: HeaderCarrier, _: ExecutionContext))
+            .expects(*, allEnrolments and confidenceLevel, *, *)
+            .returning(Future.successful(enrolments and ConfidenceLevel.L250))
+          auth.individualAuthentication[AnyContent](block)(FakeRequest(), emptyHeaderCarrier)
+        }
+
+        "returns an OK status" in {
+          status(result) shouldBe SEE_OTHER
+        }
+
+        "returns a body of the mtditid" in {
+          redirectUrl(result) shouldBe "/signIn"
+        }
+      }
+    }
+
+    "return the user to IV Uplift" when {
+
+      "the confidence level is below minimum" which {
+
+        val enrolments = Enrolments(Set(
+          Enrolment(EnrolmentKeys.Individual, Seq(EnrolmentIdentifier(EnrolmentIdentifiers.individualId, mtditid)), "Activated"),
+          Enrolment(EnrolmentKeys.nino, Seq(EnrolmentIdentifier(EnrolmentIdentifiers.ninoId, "AA123456A")), "Activated")
+        ))
+
+        lazy val result: Future[Result] = {
+          (mockAuthConnector.authorise(_: Predicate, _: Retrieval[_])(_: HeaderCarrier, _: ExecutionContext))
+            .expects(*, allEnrolments and confidenceLevel, *, *)
+            .returning(Future.successful(enrolments and ConfidenceLevel.L50))
+          auth.individualAuthentication[AnyContent](block)(fakeRequest, emptyHeaderCarrier)
+        }
+
+        "has a status of 303" in {
+          status(result) shouldBe SEE_OTHER
+        }
+
+        "redirects to the iv url" in {
+          await(result).header.headers("Location") shouldBe "/update-and-submit-income-tax-return/iv-uplift"
+        }
+      }
+    }
+  }
+
+  ".agentAuthenticated" when {
+    "MTD ID and/or NINO are not found in the session" should {
+      "return a redirect to View and Change service" in new AgentTest {
+        val result: Future[Result] = testAuth.agentAuthentication(testBlock)(
+          request = FakeRequest().withSession(fakeRequest.session.data.toSeq :_*),
+          hc = emptyHeaderCarrier
+        )
+
+        status(result) shouldBe SEE_OTHER
+        redirectUrl(result) shouldBe viewAndChangeUrl
+      }
+    }
+
+    "NINO and MTD IT ID are present in the session" which {
+      "results in a NoActiveSession error to be returned from Auth" should {
+        "return a redirect to the login page" in new AgentTest {
+          object AuthException extends NoActiveSession("Some reason")
+          mockAuthReturnException(AuthException, primaryAgentPredicate(mtditid))
+
+          val result: Future[Result] = testAuth.agentAuthentication(testBlock)(
+            request = FakeRequest().withSession(fakeRequestWithMtditidAndNino.session.data.toSeq :_*),
+            hc = emptyHeaderCarrier
+          )
+
+          status(result) shouldBe SEE_OTHER
+          redirectUrl(result) shouldBe s"$baseUrl/signIn"
+        }
+      }
+
+      "[EMA disabled] results in an AuthorisationException error being returned from Auth" should {
+        "return a redirect to the agent error page" in new AgentTest {
+          mockMultipleAgentsSwitch(false)
+
+          object AuthException extends AuthorisationException("Some reason")
+          mockAuthReturnException(AuthException, primaryAgentPredicate(mtditid))
+
+          val result: Future[Result] = testAuth.agentAuthentication(testBlock)(
+            request = FakeRequest().withSession(fakeRequestWithMtditidAndNino.session.data.toSeq :_*),
+            hc = emptyHeaderCarrier
+          )
+
+          status(result) shouldBe SEE_OTHER
+          redirectUrl(result) shouldBe s"$baseUrl/error/you-need-client-authorisation"
+        }
+      }
+
+      "[EMA enabled] results in an AuthorisationException error being returned from Auth" should {
+        "return a redirect to the agent error page when secondary agent auth call also fails" in new AgentTest {
+          mockMultipleAgentsSwitch(true)
+
+          object AuthException extends AuthorisationException("Some reason")
+          mockAuthReturnException(AuthException, primaryAgentPredicate(mtditid))
+          mockAuthReturnException(AuthException, secondaryAgentPredicate(mtditid))
+
+          lazy val result: Future[Result] = testAuth.agentAuthentication(testBlock)(
+            request = FakeRequest().withSession(fakeRequestWithMtditidAndNino.session.data.toSeq :_*),
+            hc = emptyHeaderCarrier
+          )
+
+          status(result) shouldBe SEE_OTHER
+          redirectUrl(result) shouldBe s"$baseUrl/error/you-need-client-authorisation"
+        }
+
+        "handle appropriately when a supporting agent is properly authorised" in new AgentTest {
+          mockMultipleAgentsSwitch(true)
+
+          object AuthException extends AuthorisationException("Some reason")
+          mockAuthReturnException(AuthException, primaryAgentPredicate(mtditid))
+          mockAuthReturn(supportingAgentEnrolment, secondaryAgentPredicate(mtditid))
+
+          lazy val result: Future[Result] = testAuth.agentAuthentication(testBlock)(
+            request = FakeRequest().withSession(fakeRequestWithMtditidAndNino.session.data.toSeq :_*),
+            hc = validHeaderCarrier
+          )
+
+          status(result) shouldBe OK
+          bodyOf(result) shouldBe s"$mtditid $arn"
+        }
+      }
+
+      "results in successful authorisation for a primary agent" should {
+        "return a redirect to You Need Agent Services page when an ARN cannot be found" in new AgentTest {
+          val primaryAgentEnrolmentNoArn: Enrolments = Enrolments(Set(
+            Enrolment(EnrolmentKeys.Individual, Seq(EnrolmentIdentifier(EnrolmentIdentifiers.individualId, mtditid)), "Activated"),
+            Enrolment(EnrolmentKeys.Agent, Seq.empty, "Activated")
+          ))
+
+          mockAuthReturn(primaryAgentEnrolmentNoArn, primaryAgentPredicate(mtditid))
+
+          lazy val result: Future[Result] = testAuth.agentAuthentication(testBlock)(
+            request = FakeRequest().withSession(fakeRequestWithMtditidAndNino.session.data.toSeq :_*),
+            hc = validHeaderCarrier
+          )
+
+          status(result) shouldBe SEE_OTHER
+          redirectUrl(result) shouldBe s"$baseUrl/error/you-need-agent-services-account"
+        }
+
+        "return a redirect to Sign In page when a session ID cannot be found" in new AgentTest {
+          mockAuthReturn(primaryAgentEnrolment, primaryAgentPredicate(mtditid))
+
+          lazy val result: Future[Result] = testAuth.agentAuthentication(testBlock)(
+            request = FakeRequest().withSession(fakeRequestWithMtditidAndNino.session.data.toSeq :_*),
+            hc = emptyHeaderCarrier
+          )
+
+          status(result) shouldBe SEE_OTHER
+          redirectUrl(result) shouldBe s"$baseUrl/signIn"
+        }
+
+        "invoke block when the user is properly authenticated" in new AgentTest {
+          mockAuthReturn(primaryAgentEnrolment, primaryAgentPredicate(mtditid))
+
+          lazy val result: Future[Result] = testAuth.agentAuthentication(testBlock)(
+            request = FakeRequest().withSession(fakeRequestWithMtditidAndNino.session.data.toSeq :_*),
+            hc = validHeaderCarrier
+          )
+
+          status(result) shouldBe OK
+          bodyOf(result) shouldBe s"$mtditid $arn"
+        }
+      }
+    }
+  }
+
+  ".invokeBlock" should {
+
+    lazy val block: User[AnyContent] => Future[Result] = user =>
+      Future.successful(Ok(s"mtditid: ${user.mtditid}${user.arn.fold("")(arn => " arn: " + arn)}"))
+
+    "perform the block action" when {
+
+      "the user is successfully verified as an agent" which {
+
+        lazy val result = {
+          mockAuthAsAgent()
+          auth.invokeBlock(fakeRequestWithMtditidAndNino, block)
+        }
+
+        "should return an OK(200) status" in {
+          status(result) shouldBe OK
+          bodyOf(result) shouldBe "mtditid: 1234567890 arn: 0987654321"
+        }
+      }
+
+      "the user is successfully verified as an individual" in {
+
+        lazy val result = {
+          mockAuth(Some("AA123456A"))
+          auth.invokeBlock(fakeRequest, block)
+        }
+
+        status(result) shouldBe OK
+
+        bodyOf(result) shouldBe "mtditid: 1234567890"
+      }
+    }
+
+    "return a redirect" when {
+
+      "the authorisation service returns an AuthorisationException exception" in {
+        object AuthException extends AuthorisationException("Some reason")
+
+        lazy val result = {
+          mockAuthReturnException(AuthException)
+          auth.invokeBlock(fakeRequest, block)
+        }
+        status(result) shouldBe SEE_OTHER
+      }
+
+      "there is no MTDITID value in session for an agent" in {
+        lazy val result = {
+
+          (mockAuthConnector.authorise(_: Predicate, _: Retrieval[_])(_: HeaderCarrier, _: ExecutionContext))
+            .expects(*, Retrievals.affinityGroup, *, *)
+            .returning(Future.successful(Some(AffinityGroup.Agent)))
+
+          auth.invokeBlock(fakeRequestWithNino, block)
+        }
+        status(result) shouldBe SEE_OTHER
+        redirectUrl(result) shouldBe "/utr-entry"
+      }
+
+    }
+
+    "redirect to the sign in page" when {
+      "the authorisation service returns a NoActiveSession exception" in {
+        object NoActiveSession extends NoActiveSession("Some reason")
+
+        lazy val result = {
+          mockAuthReturnException(NoActiveSession)
+          auth.invokeBlock(fakeRequest, block)
+        }
+
+        status(result) shouldBe SEE_OTHER
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
### Description
Add's new secondary agent delegated auth check. Adds a `isSecondaryAgent` boolean to the `User` class for later use in Controllers/Services/Views if needed to distinguish between Primary Agent and Secondary Agents.

Required App-Config-* PR(s):
- https://github.com/hmrc/app-config-base/pull/11364

Add a link to the relevant story in Jira:
[SASS-10357](https://jira.tools.tax.service.gov.uk/browse/SASS-10357)

### Checklist PR Reviewer
##### Before Reviewing
- [ ]  Have you pulled the branch down?
- [ ]  Have you assigned yourself to the PR?
- [ ]  Have you moved the task to “in review” on JIRA?
- [ ]  Have you checked to ensure all dependencies are up to date?
- [ ]  Have you checked to ensure its been rebased against the current version of main?

##### Whilst Reviewing
- [ ]  Have you run the tests?
- [ ]  Have you run the journey tests?
- [ ]  Have you looked at the JIRA story to make sure all Acceptance Criteria has been met?

##### After Reviewing
- [ ]  Have you checked for merge conflicts or any changes in the current main that may affect the current pull request? i.e. does it need another rebase?
- [ ]  Have you checked to make sure there are no builds in the pipeline before you merge?
- [ ]  Have you moved the task to “in pipeline” on Jira?

### Checklist PR Raiser
##### Before creating PR
- [ ]  Have you run the tests?
- [ ]  Have you run the journey tests? (where applicable)
- [ ]  Have you addressed warnings where appropriate?
- [ ]  Have you rebased against the current version of main?
- [ ]  Have you checked code coverage isn’t lower than previously?

##### After PRs been raised
- [ ]  Have you checked the PR Builder passes?
