### PR TITLE
SASS-11611 Remove memoization of tax year in Submissions Frontend

### DIFF
--- a/app/config/AppConfig.scala
+++ b/app/config/AppConfig.scala
@@ -28,7 +28,9 @@ import javax.inject.Inject
 import scala.concurrent.duration.Duration
 
 //scalastyle:off
-class FrontendAppConfig @Inject()(servicesConfig: ServicesConfig) extends AppConfig with TaxYearHelper {
+class FrontendAppConfig @Inject()(servicesConfig: ServicesConfig,
+                                  taxYearHelper: TaxYearHelper) extends AppConfig {
+
   private lazy val signInBaseUrl: String = servicesConfig.getString(ConfigKeys.signInUrl)
   def defaultTaxYear: Int = servicesConfig.getInt(ConfigKeys.defaultTaxYear)
   val alwaysEOY: Boolean = servicesConfig.getBoolean(ConfigKeys.alwaysEOY)
@@ -198,7 +200,7 @@ class FrontendAppConfig @Inject()(servicesConfig: ServicesConfig) extends AppCon
   def tailorReturnAddSectionsPageUrl(taxYear: Int): String = s"$tailorReturnServiceUrl/$taxYear/add-sections"
 
   def excludedIncomeSources(inputTaxYear: Int): Seq[String] = {
-    val employmentFeatureEnabled: (String, Boolean) = if(inputTaxYear != taxYear) (EMPLOYMENT, employmentEOYEnabled) else (EMPLOYMENT, employmentEnabled)
+    val employmentFeatureEnabled: (String, Boolean) = if(inputTaxYear != taxYearHelper.taxYear) (EMPLOYMENT, employmentEOYEnabled) else (EMPLOYMENT, employmentEnabled)
     Seq(
       (DIVIDENDS, dividendsEnabled),
       (INTEREST, interestEnabled),

--- a/app/config/Modules.scala
+++ b/app/config/Modules.scala
@@ -18,10 +18,13 @@ package config
 
 import com.google.inject.AbstractModule
 
+import java.time.Clock
+
 class Modules extends AbstractModule {
 
   override def configure(): Unit = {
     bind(classOf[AppConfig]).asEagerSingleton()
+    bind(classOf[Clock]).toInstance(Clock.systemUTC())
   }
 
 }

--- a/app/controllers/TaxYearErrorController.scala
+++ b/app/controllers/TaxYearErrorController.scala
@@ -23,7 +23,7 @@ import javax.inject.Inject
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
-import utils.TaxYearHelper
+import utils.SessionDataHelper
 import views.html.errors.WrongTaxYearPage
 
 import scala.concurrent.Future
@@ -32,11 +32,10 @@ class TaxYearErrorController @Inject()(val authorisedAction: AuthorisedAction,
                                        val mcc: MessagesControllerComponents,
                                        wrongTaxYearPage: WrongTaxYearPage,
                                        implicit val appConfig: AppConfig)
-  extends FrontendController(mcc) with I18nSupport with TaxYearHelper {
+  extends FrontendController(mcc) with I18nSupport with SessionDataHelper {
 
-  def show: Action[AnyContent] = authorisedAction.async { implicit request =>
-
-    Future.successful(Ok(wrongTaxYearPage(firstClientTaxYear, latestClientTaxYear, singleValidTaxYear)))
+  def show: Action[AnyContent] = authorisedAction { implicit request =>
+    Ok(wrongTaxYearPage(firstClientTaxYear, latestClientTaxYear, singleValidTaxYear))
   }
 
 }

--- a/app/utils/SessionDataHelper.scala
+++ b/app/utils/SessionDataHelper.scala
@@ -16,10 +16,21 @@
 
 package utils
 
+import common.SessionValues
+import models.User
 import play.api.libs.json.{Json, Reads}
 import play.api.mvc.Request
 
 trait SessionDataHelper {
+  def retrieveTaxYearList(implicit user: User[_]): Seq[Int] = {
+    user.session.get(SessionValues.VALID_TAX_YEARS).getOrElse("").split(",").toSeq.map(_.toInt)
+  }
+
+  def firstClientTaxYear(implicit user: User[_]): Int = retrieveTaxYearList.head
+  def latestClientTaxYear(implicit user: User[_]): Int = retrieveTaxYearList.last
+
+  def singleValidTaxYear(implicit user: User[_]): Boolean = firstClientTaxYear == latestClientTaxYear
+
   def getSessionData[T](key: String)(implicit request: Request[_], reads: Reads[T]): Option[T] = {
     request.session.get(key).flatMap { stringValue =>
       Json.parse(stringValue).asOpt[T]

--- a/app/utils/TaxYearHelper.scala
+++ b/app/utils/TaxYearHelper.scala
@@ -16,12 +16,9 @@
 
 package utils
 
-import common.SessionValues
-import models.User
-
 import java.time.LocalDate
 
-trait TaxYearHelper extends SessionDataHelper {
+trait TaxYearHelper {
 
   /*
    * TODO: Fix.

--- a/app/utils/TaxYearHelper.scala
+++ b/app/utils/TaxYearHelper.scala
@@ -39,12 +39,4 @@ trait TaxYearHelper extends SessionDataHelper {
 
   val taxYear: Int = if (dateNow.isAfter(taxYearCutoffDate)) LocalDate.now().getYear + 1 else LocalDate.now().getYear
 
-  def retrieveTaxYearList(implicit user: User[_]): Seq[Int] = {
-    user.session.get(SessionValues.VALID_TAX_YEARS).getOrElse("").split(",").toSeq.map(_.toInt)
-  }
-
-  def firstClientTaxYear(implicit user: User[_]): Int = retrieveTaxYearList.head
-  def latestClientTaxYear(implicit user: User[_]): Int = retrieveTaxYearList.last
-
-  def singleValidTaxYear(implicit user: User[_]): Boolean = firstClientTaxYear == latestClientTaxYear
 }

--- a/app/utils/TaxYearHelper.scala
+++ b/app/utils/TaxYearHelper.scala
@@ -16,24 +16,21 @@
 
 package utils
 
-import java.time.LocalDate
+import com.google.inject.Singleton
 
-trait TaxYearHelper {
+import java.time.{Clock, LocalDate}
+import javax.inject.Inject
 
-  /*
-   * TODO: Fix.
-   *  Summary: This will memoize the date and can be lead to incorrect usage at call site.
-   *  Action: Remove and use a Clock instance set to UTC.
-   */
-  private val dateNow: LocalDate = LocalDate.now()
+@Singleton
+class TaxYearHelper @Inject()(clock: Clock) {
 
-  /*
-   * TODO: Fix.
-   *  Summary: This will potentially return the wrong tax year if the app is not redeployed on a new tax year.
-   *  Action: Replace with a def and also pass Clock instance set to UTC
-   */
-  private val taxYearCutoffDate: LocalDate = LocalDate.parse(s"${dateNow.getYear}-04-05")
+  def taxYear: Int = {
+    val now = LocalDate.now(clock)
 
-  val taxYear: Int = if (dateNow.isAfter(taxYearCutoffDate)) LocalDate.now().getYear + 1 else LocalDate.now().getYear
+    //noinspection ScalaStyle
+    val taxYearCutoffDate: LocalDate = LocalDate.of(now.getYear, 4, 5)
+
+    if (now.isAfter(taxYearCutoffDate)) now.getYear + 1 else now.getYear
+  }
 
 }

--- a/test/config/MockAppConfig.scala
+++ b/test/config/MockAppConfig.scala
@@ -19,10 +19,9 @@ package config
 import org.scalamock.scalatest.MockFactory
 import play.api.i18n.Lang
 import play.api.mvc.{Call, RequestHeader}
-import utils.TaxYearHelper
 
 //noinspection ScalaStyle
-class MockAppConfig extends AppConfig with MockFactory with TaxYearHelper {
+class MockAppConfig extends AppConfig with MockFactory {
 
   override lazy val signInContinueUrl: String = "/signInContinue"
   override lazy val signInUrl: String = "/signIn"


### PR DESCRIPTION
- SASS-11611 refactor SessionDataHelper and TaxYearHelper
- SASS-11611 use SessionDataHelper directly
- SASS-11611 Remove memoization of tax year in Submissions Frontend
